### PR TITLE
Remove Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ bundler_args: --path vendor/bundle
 
 script:
   - bundle exec rake test
+
+addons:
+  code_climate:
+    repo_token:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'codeclimate-test-reporter', :group => :test, :require => nil

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/minitest-filesystem.svg)](http://badge.fury.io/rb/minitest-filesystem)
 [![Build Status](https://travis-ci.org/stefanozanella/minitest-filesystem.svg?branch=master)](https://travis-ci.org/stefanozanella/minitest-filesystem)
 [![Code Climate](https://codeclimate.com/github/stefanozanella/minitest-filesystem.svg)](https://codeclimate.com/github/stefanozanella/minitest-filesystem)
-[![Coverage Status](https://coveralls.io/repos/stefanozanella/minitest-filesystem/badge.png?branch=master)](https://coveralls.io/r/stefanozanella/minitest-filesystem?branch=master)
 
 Adds assertions and expectations to check filesystem content in a communicative way.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Gem Version](https://badge.fury.io/rb/minitest-filesystem.svg)](http://badge.fury.io/rb/minitest-filesystem)
 [![Build Status](https://travis-ci.org/stefanozanella/minitest-filesystem.svg?branch=master)](https://travis-ci.org/stefanozanella/minitest-filesystem)
-[![Code Climate](https://codeclimate.com/github/stefanozanella/minitest-filesystem.svg)](https://codeclimate.com/github/stefanozanella/minitest-filesystem)
+[![Code Climate](https://codeclimate.com/github/stefanozanella/minitest-filesystem/badges/gpa.svg)](https://codeclimate.com/github/stefanozanella/minitest-filesystem)
+[![Test Coverage](https://codeclimate.com/github/stefanozanella/minitest-filesystem/badges/coverage.svg)](https://codeclimate.com/github/stefanozanella/minitest-filesystem)
 
 Adds assertions and expectations to check filesystem content in a communicative way.
 

--- a/minitest-filesystem.gemspec
+++ b/minitest-filesystem.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest"
-  gem.add_development_dependency "coveralls"
   gem.add_development_dependency "flog"
   gem.add_development_dependency "flay"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 require 'minitest/autorun'
 require 'minitest/spec'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear!
-
 require 'minitest/autorun'
 require 'minitest/spec'
 


### PR DESCRIPTION
Coveralls is a plague. Code Climate can check the coverage too. Should I add the coverage from Code Climate?