### PR TITLE
Changed File.exists? to File.exist?

### DIFF
--- a/lib/minitest/filesystem.rb
+++ b/lib/minitest/filesystem.rb
@@ -8,11 +8,11 @@ module Minitest::Assertions
   end
 
   def assert_exists(path, msg = nil, &block)
-    assert File.exists?(path), msg || "expected `#{path}` to exist, but it doesn't"
+    assert File.exist?(path), msg || "expected `#{path}` to exist, but it doesn't"
   end
 
   def refute_exists(path, msg = nil, &block)
-    refute File.exists?(path), msg || "expected `#{path}` not to exist, but it does"
+    refute File.exist?(path), msg || "expected `#{path}` not to exist, but it does"
   end
 
   def filesystem(&block)


### PR DESCRIPTION
This commit fixes this annoying log message in Ruby 2.5.0.
``minitest-filesystem-1.2.0/lib/minitest/filesystem.rb:11: warning: File.exists? is a deprecated name, use File.exist? instead``